### PR TITLE
off by one error in the Write method.

### DIFF
--- a/Zforce/src/Zforce.cpp
+++ b/Zforce/src/Zforce.cpp
@@ -52,7 +52,7 @@ int Zforce::Read(uint8_t * payload)
  */
 int Zforce::Write(uint8_t* payload)
 {
-  int len = payload[1] + 2;
+  int len = payload[1] + 1;
   int status = I2c.write(ZFORCE_I2C_ADDRESS, payload[0], &payload[1], len);
 
   return status; // return 0 if success, otherwise error code according to Atmel Data Sheet


### PR DESCRIPTION
The write method added too much to the length before writing which could cause instability issues. Decreased from 2 to 1.