### PR TITLE
Fixed bug which caused the touch descriptor to not parse correctly

### DIFF
--- a/library.json
+++ b/library.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/neonode-inc/zforce-arduino"
   },
-  "version": "1.6.1",
+  "version": "1.6.2",
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=zForce Air Library
-version=1.6.1
+version=1.6.2
 author=Neonode (support@neonode.com)
 maintainer=Neonode (support@neonode.com)
 sentence=A library that makes it easy to communicate with the zForce AIR Sensor.

--- a/src/Zforce.cpp
+++ b/src/Zforce.cpp
@@ -490,9 +490,9 @@ void Zforce::ParseTouchDescriptor(TouchDescriptorMessage* msg, uint8_t* payload)
   uint8_t amountBits = ((payload[11] - 1) * 8) - payload[12];
 
   uint32_t descr = 0;
-  descr |= payload[13] << 24;
-  descr |= payload[14] << 16;
-  descr |= payload[15] << 8;
+  descr |= (uint32_t)payload[13] << 24;
+  descr |= (uint32_t)payload[14] << 16;
+  descr |= (uint32_t)payload[15] << 8;
 
   msg->descriptor = new TouchDescriptor[(int)TouchDescriptor::MaxValue];
   uint8_t bitIndex = 0;


### PR DESCRIPTION
There was a missing cast from a uint8_t to a uint32_t which caused an issue on one MCU architecture but not on another.