### PR TITLE
Bugfix/al 48 i2c size fix

### DIFF
--- a/src/Zforce.h
+++ b/src/Zforce.h
@@ -18,7 +18,7 @@
 */
 #pragma once
 
-#define MAX_PAYLOAD 127
+#define MAX_PAYLOAD 255
 #define ZFORCE_I2C_ADDRESS 0x50
 
 enum TouchEvent


### PR DESCRIPTION
Buffer size changed from 127 to 255, since the sensors at some point started sending 255 byte payloads of i2c as opposed to 127. This led to a buffer overrun, since there was no input validation at all.