### PR TITLE
Make MCU-Id and firmware version available after startup

### DIFF
--- a/src/Zforce.cpp
+++ b/src/Zforce.cpp
@@ -72,6 +72,8 @@ void Zforce::Start(int dr, int i2cAddress)
 
   this->DestroyMessage(msg);
  
+  // Get Device and Platform information
+  this->GetDeviceInformation();
 }
 
 int Zforce::Read(uint8_t * payload)
@@ -329,6 +331,23 @@ bool Zforce::TouchFormat()
   else
   {
     lastSentMessage = MessageType::TOUCHFORMATTYPE;
+  }
+
+  return !failed;
+}
+
+bool Zforce::GetDeviceInformation()
+{
+  bool failed = false;
+  uint8_t deviceInformation[] = {0xEE, 0x08, 0xEE, 0x06, 0x40, 0x02, 0x00, 0x00, 0x6C, 0x00};
+
+  if (Write(deviceInformation))
+  {
+    failed = true;
+  }
+  else
+  {
+    lastSentMessage = MessageType::DEVICEINFORMATIONTYPE;
   }
 
   return !failed;

--- a/src/Zforce.cpp
+++ b/src/Zforce.cpp
@@ -612,40 +612,40 @@ void Zforce::ParsePlatformInformation(PlatformInformationMessage *msg, uint8_t *
         uint32_t platformInformationLength = GetLength(&rawData[1]);
         rawData += GetNumLengthBytes(&rawData[1]) + 1;
         uint32_t position = 0;
-        
+
         while (position < platformInformationLength)
         {
           switch (rawData[position++])
           {
-          case 0x84: // FirmwareVersionMajor
-            uint16_t firmwareVersionMajor;
-            DecodeUint16(rawData, &position, &firmwareVersionMajor);
-            msg->firmwareVersionMajor = firmwareVersionMajor;
-            break;
-          case 0x85: // FirmwareVersionMinor
-            uint16_t firmwareVersionMinor;
-            DecodeUint16(rawData, &position, &firmwareVersionMinor);
-            msg->firmwareVersionMinor = firmwareVersionMinor;
-            break;
-          case 0x8A: // MCUUniqueIdentifier
-            uint8_t *MCUUniqueIdentifier = nullptr;
-            uint32_t MCUUniqueIdentifierLength;
-            DecodeOctetString(rawData, &position, &MCUUniqueIdentifierLength, &MCUUniqueIdentifier);
+            case 0x84: // FirmwareVersionMajor
+              uint16_t firmwareVersionMajor;
+              DecodeUint16(rawData, &position, &firmwareVersionMajor);
+              msg->firmwareVersionMajor = firmwareVersionMajor;
+              break;
+            case 0x85: // FirmwareVersionMinor
+              uint16_t firmwareVersionMinor;
+              DecodeUint16(rawData, &position, &firmwareVersionMinor);
+              msg->firmwareVersionMinor = firmwareVersionMinor;
+              break;
+            case 0x8A: // MCUUniqueIdentifier
+              uint8_t *MCUUniqueIdentifier = nullptr;
+              uint32_t MCUUniqueIdentifierLength;
+              DecodeOctetString(rawData, &position, &MCUUniqueIdentifierLength, &MCUUniqueIdentifier);
 
-            const size_t bufferSize = 100;
-            char buffer[bufferSize];
-            int writeSize = 0;
-            for (size_t i = 0; i < MCUUniqueIdentifierLength; i++)
-            {
-              writeSize += snprintf(buffer + writeSize, bufferSize - writeSize, "%02X", MCUUniqueIdentifier[i]);
-            }
-            msg->mcuUniqueIdentifier = buffer;
-            msg->mcuUniqueIdentifierLength = writeSize;
-            break;
-          default:
-            position += rawData[position];
-            position++;
-            break;
+              const size_t bufferSize = 100;
+              char buffer[bufferSize];
+              int writeSize = 0;
+              for (size_t i = 0; i < MCUUniqueIdentifierLength; i++)
+              {
+                writeSize += snprintf(buffer + writeSize, bufferSize - writeSize, "%02X", MCUUniqueIdentifier[i]);
+              }
+              msg->mcuUniqueIdentifier = buffer;
+              msg->mcuUniqueIdentifierLength = writeSize;
+              break;
+            default:
+              position += rawData[position];
+              position++;
+              break;
           }
         }
       }

--- a/src/Zforce.h
+++ b/src/Zforce.h
@@ -23,10 +23,6 @@
 // The buffer must be able to contain both the i2c header, and MAX_PAYLOAD size.
 #define BUFFER_SIZE (MAX_PAYLOAD+2)
 #define ZFORCE_DEFAULT_I2C_ADDRESS 0x50
-// APPLICATION 12 SEQUENCE
-#define ASN1DEVICEINFORMATION 0x6C
-// CONTEXT 0 SEQUENCE
-#define ASN1PLATFORMINFORMATION 0xA0
 
 enum TouchEvent
 {
@@ -297,10 +293,6 @@ class Zforce
 		void ParsePlatformInformation(PlatformInformationMessage* msg, uint8_t* rawData, uint32_t length);
 		void ClearBuffer(uint8_t* buffer);
 		uint8_t SerializeInt(int32_t value, uint8_t* serialized);
-		int GetLength(uint8_t* rawData);
-		int GetNumLengthBytes(uint8_t* rawData);
-		void DecodeUint16(uint8_t* rawData, uint32_t* position, uint16_t* value);
-		void DecodeUint32(uint8_t* rawData, uint32_t* position, uint32_t* value);
 		void DecodeOctetString(uint8_t* rawData, uint32_t* position, uint32_t* destinationLength, uint8_t** destination);
 		uint8_t buffer[BUFFER_SIZE];
 		int dataReady;

--- a/src/Zforce.h
+++ b/src/Zforce.h
@@ -252,6 +252,7 @@ class Zforce
 		int GetDataReady();
 		Message* GetMessage();
 		void DestroyMessage(Message * msg);
+        bool GetDeviceInformation();
     private:
 		Message* VirtualParse(uint8_t* payload);
 		void ParseTouchActiveArea(TouchActiveAreaMessage* msg, uint8_t* payload);

--- a/src/Zforce.h
+++ b/src/Zforce.h
@@ -294,6 +294,8 @@ class Zforce
 		void ClearBuffer(uint8_t* buffer);
 		uint8_t SerializeInt(int32_t value, uint8_t* serialized);
 		void DecodeOctetString(uint8_t* rawData, uint32_t* position, uint32_t* destinationLength, uint8_t** destination);
+		uint16_t GetLength(uint8_t* rawData);
+		uint8_t GetNumLengthBytes(uint8_t* rawData);
 		uint8_t buffer[BUFFER_SIZE];
 		int dataReady;
 		int i2cAddress;

--- a/src/Zforce.h
+++ b/src/Zforce.h
@@ -20,6 +20,10 @@
 
 #define MAX_PAYLOAD 255
 #define ZFORCE_DEFAULT_I2C_ADDRESS 0x50
+// APPLICATION 12 SEQUENCE
+#define ASN1DEVICEINFORMATION 0x6C
+// CONTEXT 0 SEQUENCE
+#define ASN1PLATFORMINFORMATION 0xA0
 
 enum TouchEvent
 {
@@ -45,7 +49,8 @@ enum class MessageType
 	DETECTIONMODETYPE = 10,
 	TOUCHFORMATTYPE = 11,
 	TOUCHMODETYPE = 12,
-	FLOATINGPROTECTIONTYPE = 13
+	FLOATINGPROTECTIONTYPE = 13,
+	PLATFORMINFORMATIONTYPE = 14
 };
 
 typedef struct TouchData
@@ -213,6 +218,19 @@ typedef struct TouchDescriptorMessage : public Message
 
 } TouchDescriptorMessage;
 
+typedef struct PlatformInformationMessage : public Message
+{
+	virtual ~PlatformInformationMessage()
+	{
+		delete[] mcuUniqueIdentifier;
+		mcuUniqueIdentifier = nullptr;
+	}
+	uint8_t firmwareVersionMajor;
+	uint8_t firmwareVersionMinor;
+	char* mcuUniqueIdentifier;
+	uint8_t mcuUniqueIdentifierLength;
+} PlatformInformationMessage;
+
 typedef struct FloatingProtectionMessage : public Message
 {
 	virtual ~FloatingProtectionMessage()
@@ -252,7 +270,10 @@ class Zforce
 		int GetDataReady();
 		Message* GetMessage();
 		void DestroyMessage(Message * msg);
-        bool GetDeviceInformation();
+		bool GetPlatformInformation();
+		uint8_t FirmwareVersionMajor;
+		uint8_t FirmwareVersionMinor;
+		char* MCUUniqueIdentifier;
     private:
 		Message* VirtualParse(uint8_t* payload);
 		void ParseTouchActiveArea(TouchActiveAreaMessage* msg, uint8_t* payload);
@@ -268,7 +289,13 @@ class Zforce
 		void ParseTouchDescriptor(TouchDescriptorMessage* msg, uint8_t* payload);
 		void ParseTouchMode(TouchModeMessage* msg, uint8_t* payload);
 		void ParseFloatingProtection(FloatingProtectionMessage* msg, uint8_t* payload);
+		void ParsePlatformInformation(PlatformInformationMessage* msg, uint8_t* rawData, uint32_t length);
 		void ClearBuffer(uint8_t* buffer);
+		int GetLength(uint8_t* rawData);
+		int GetNumLengthBytes(uint8_t* rawData);
+		void DecodeUint16(uint8_t* rawData, uint32_t* position, uint16_t* value);
+		void DecodeUint32(uint8_t* rawData, uint32_t* position, uint32_t* value);
+		void DecodeOctetString(uint8_t* rawData, uint32_t* position, uint32_t* destinationLength, uint8_t** destination);
 		uint8_t buffer[MAX_PAYLOAD];
 		int dataReady;
 		int i2cAddress;


### PR DESCRIPTION
MCU-Id and firmware version are fetched at startup and made available in the zForce object.