### PR TITLE
Bugfix/al 141 click on touch workaround for 1.x firwmares

### DIFF
--- a/src/Zforce.cpp
+++ b/src/Zforce.cpp
@@ -951,6 +951,9 @@ void Zforce::ParseTouchMode(TouchModeMessage* msg, uint8_t* payload)
   const uint8_t offset = 9;
   uint16_t valueLength = 0;
 
+  msg->clickOnTouchTime = -1;   // FW <=1.55 doesn't reply properly when mode = Disabled.
+  msg->clickOnTouchRadius = -1; // We set them to -1, signaling the data is invalid.
+
   for (int i = offset; i < payload[10] + offset; i++)
   {
     switch (payload[i])


### PR DESCRIPTION
Firmwares <= 1.55 have a bug, that when you send a disable ClickOnTouch, it does not return the values in the time and radius fields, which it should. The workaround is to initialize them to -1, before parsing the response. That way -1 indicates that the data was not populated.